### PR TITLE
Add envvar controls of basic config options

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@
 cat <<EOF
 ---
 default_process_types:
-  web: sh ./heka/run.sh
+  web: ./heka/run.sh
 EOF

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,8 +1,14 @@
-set -x
+#!/bin/bash
+[[ ${SHELL_TRACE} ]] && set -x
+set -euo pipefail
+
 export APP_ROOT=$HOME
 : ${HEKA_SHARE_DIR:=${APP_ROOT}/heka/share/heka}
 : ${HEKA_BASE_DIR:=/tmp}
+: ${HEKA_MAX_PROCS:=2}
+
 export HEKA_SHARE_DIR
 export HEKA_BASE_DIR
+export HEKA_MAX_PROCS
 
 exec ${APP_ROOT}/heka/bin/hekad -config="${APP_ROOT}/heka/conf/"

--- a/conf/000-global.toml
+++ b/conf/000-global.toml
@@ -1,4 +1,4 @@
 [hekad]
-maxprocs = 1
-base_dir = "/tmp"
-share_dir = "heka/share/heka"
+maxprocs = %ENV[HEKA_MAX_PROCS]
+base_dir = "%ENV[HEKA_BASE_DIR]"
+share_dir = "%ENV[HEKA_SHARE_DIR]"


### PR DESCRIPTION
This changes the buildpack default config to reference 3 envvars:
- `HEKA_MAX_PROCS`: sets `heka::maxprocs`
- `HEKA_BASE_DIR`: sets `heka::base_dir`
- `HEKA_SHARE_DIR`: sets `heka::share_dir`
